### PR TITLE
feat(authz): add modules and permission management integration

### DIFF
--- a/app/Http/Controllers/Module/IndexController.php
+++ b/app/Http/Controllers/Module/IndexController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\Module;
+
+use App\Http\Controllers\Controller;
+use App\Models\Module;
+
+class IndexController extends Controller
+{
+    public function __invoke()
+    {
+        $modules = Module::with(['permissionsMetas' => function ($query) {
+            $query->select('id', 'module_id', 'menu', 'permission_name', 'action', 'route_name');
+        }])->get(['id', 'name', 'description']);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'List of modules with permissions',
+            'data' => $modules,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Permission/IndexController.php
+++ b/app/Http/Controllers/Permission/IndexController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\Permission;
+
+use App\Http\Controllers\Controller;
+use App\Models\PermissionsMeta;
+
+class IndexController extends Controller
+{
+    public function __invoke()
+    {
+        $permissions = PermissionsMeta::query()
+            ->select('module', 'menu', 'permission_name', 'action')
+            ->get()
+            ->groupBy(['module', 'menu']);
+
+        return response()->json([
+            'success' => true,
+            'data' => $permissions,
+        ]);
+    }
+}

--- a/app/Http/Requests/Department/StoreRequest.php
+++ b/app/Http/Requests/Department/StoreRequest.php
@@ -4,39 +4,21 @@ namespace App\Http\Requests\Department;
 
 use App\Models\Department;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Validation\Rule;
 
 class StoreRequest extends FormRequest
 {
-    /**
-     * Tentukan apakah user diizinkan untuk membuat request ini.
-     */
     public function authorize(): bool
     {
-        // Autorisasi ditangani oleh middleware 'permission' di controller.
         return true;
     }
 
-    /**
-     * Tentukan rules validasi yang berlaku untuk request (Store/Add).
-     */
     public function rules(): array
     {
         return Department::rules();
     }
 
-   
-
-    /**
-     * Tentukan pesan error kustom untuk validasi.
-     */
     public function messages(): array
     {
-        return [
-            'name.required' => 'Nama department wajib diisi.',
-            'name.unique' => 'Nama department sudah digunakan.',
-            'name.string' => 'Nama department harus berupa teks.',
-            'name.max' => 'Nama department tidak boleh lebih dari 225 karakter',
-        ];
+        return Department::MESSAGES;
     }
 }

--- a/app/Http/Requests/Department/UpdateRequest.php
+++ b/app/Http/Requests/Department/UpdateRequest.php
@@ -4,40 +4,24 @@ namespace App\Http\Requests\Department;
 
 use App\Models\Department;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Validation\Rule;
 
 /**
  * @method mixed route(string|null $param = null, mixed $default = null)
  */
 class UpdateRequest extends FormRequest
 {
-    /**
-     * Tentukan apakah user diizinkan untuk membuat request ini.
-     */
     public function authorize(): bool
     {
         return true;
     }
 
-    /**
-     * Tentukan rules validasi yang berlaku untuk request (Update/Edit).
-     */
     public function rules(): array
     {
         return Department::rules($this->route('department')->id);
-        
     }
-    
-    /**
-     * Tentukan pesan error kustom untuk validasi.
-     */
+
     public function messages(): array
     {
         return Department::MESSAGES;
-        return [
-            'name.required' => 'Nama department wajib diisi.',
-            'name.unique' => 'Nama department sudah digunakan.',
-            'name.string' => 'Nama department harus berupa teks.',
-        ];
     }
 }

--- a/app/Http/Requests/User/StoreRequest.php
+++ b/app/Http/Requests/User/StoreRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\User;
 
+use App\Models\User;
 use Illuminate\Foundation\Http\FormRequest;
 
 class StoreRequest extends FormRequest
@@ -13,14 +14,11 @@ class StoreRequest extends FormRequest
 
     public function rules(): array
     {
-        return [
-            'name' => 'required|string|max:255',
-            'username' => 'required|string|max:50|unique:users,username',
-            'email' => 'nullable|email|unique:users,email',
-            'password' => 'required|string|min:8|confirmed',
-            'role' => 'nullable|array',
-            'status' => 'nullable|in:active,inactive',
-            'photo' => 'nullable|image|mimes:jpg,jpeg,png|max:2048',
-        ];
+        return User::rules();
+    }
+
+    public function messages(): array
+    {
+        return User::MESSAGES;
     }
 }

--- a/app/Http/Requests/User/UpdateRequest.php
+++ b/app/Http/Requests/User/UpdateRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\User;
 
+use App\Models\User;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -16,26 +17,11 @@ class UpdateRequest extends FormRequest
 
     public function rules(): array
     {
-        $user = $this->route('user');
-        $userId = $user instanceof \App\Models\User ? $user->getKey() : $user;
-
-        return [
-            'name' => 'sometimes|string|max:255',
-            'username' => 'sometimes|string|max:50|unique:users,username,' . $userId,
-            'email' => 'sometimes|email|unique:users,email,' . $userId,
-            'password' => 'nullable|string|min:8|confirmed',
-            'status' => 'sometimes|in:active,inactive',
-            'photo' => 'nullable|image|max:2048', // max 2MB
-        ];
+        return User::rules($this->route("user")->id);
     }
 
     public function messages(): array
     {
-        return [
-            'email.unique' => 'Email already exists.',
-            'username.unique' => 'Username already exists.',
-            'password.confirmed' => 'Password confirmation does not match.',
-            'photo.image' => 'Photo must be an image file.',
-        ];
+        return User::MESSAGES;
     }
 }

--- a/app/Models/Department.php
+++ b/app/Models/Department.php
@@ -17,7 +17,7 @@ class Department extends Model
         'status',
         'content',
     ];
-    
+
     public function divisions()
     {
         return $this->hasMany(Division::class);
@@ -28,16 +28,31 @@ class Department extends Model
         return $this->belongsToMany(User::class, 'user_department', 'department_id', 'user_id');
     }
 
-    public static function rules($ignored = null){
+    public function getDivisionCountAttribute(): int
+    {
+        return $this->relationsLoaded('divisions')
+            ? $this->divisions->count()
+            : $this->divisions()->count();
+    }
+
+    public static function rules(?string $ignoreId = null): array
+    {
         return [
-            'name' => 'sometimes|unique:departments,name'.(is_string($ignored) ? ",$ignored,id" : ''),
-            'content' => 'sometimes|string'
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                "unique:departments,name,{$ignoreId},id",
+            ],
+            'alias' => ['nullable', 'string', 'max:50'],
+            'content' => ['nullable', 'string'],
+            'status' => ['required', 'in:active,inactive'],
         ];
     }
 
     public const MESSAGES = [
-        'name.required' => 'Nama tidak',
-        'name.unique' => 'Nama bla bla bla',
-        'content.string' => 'Kontent bla bla bla'
+        'name.required' => 'Nama department wajib diisi.',
+        'name.unique' => 'Nama department sudah digunakan.',
+        'name.string' => 'Nama department harus berupa teks.',
     ];
 }

--- a/app/Models/Module.php
+++ b/app/Models/Module.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+class Module extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $fillable = [
+        'name',
+        'slug',
+        'icon',
+        'order',
+        'description'
+    ];
+
+    public static function booted(): void
+    {
+        static::creating(function ($module) {
+            if(empty($module->slug)) {
+                $module->slug = Str::slug($module->name);
+            }
+        });
+    }
+
+    public function permissionsMetas()
+    {
+        return $this->hasMany(PermissionsMeta::class);
+    }
+}

--- a/app/Models/PermissionsMeta.php
+++ b/app/Models/PermissionsMeta.php
@@ -5,12 +5,14 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Spatie\Permission\Models\Permission;
 
 class PermissionsMeta extends Model
 {
     use HasFactory, HasUuids;
 
     protected $fillable = [
+        'module_id',
         'module',
         'menu',
         'route_name',
@@ -18,4 +20,9 @@ class PermissionsMeta extends Model
         'action',
         'description'
     ];
+
+    public function module()
+    {
+        return $this->belongsTo(Module::class);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -62,6 +62,13 @@ class User extends Authenticatable
         ];
     }
 
+    protected $appends = ["full_name"];
+
+    public function getFullNameAttribute(): string
+    {
+        return trim("{$this->first_name} {$this->last_name}");
+    }
+
     protected static function boot()
     {
         parent::boot();
@@ -73,16 +80,58 @@ class User extends Authenticatable
         });
     }
 
-    // Relasi ke Department
+    /** ────────────────────────────────
+     *  RELATIONSHIPS
+     *  ──────────────────────────────── */
     public function departments()
     {
         return $this->belongsToMany(Department::class, 'user_department', 'user_id', 'department_id');
     }
 
-    // Relasi ke Division
     public function divisions()
     {
         return $this->belongsToMany(Division::class, 'user_division', 'user_id', 'division_id')
             ->withPivot('priority');
     }
+
+    /** ────────────────────────────────
+     *  VALIDATION RULES
+     *  ──────────────────────────────── */
+    public static function rules(?string $ignoreId = null): array
+    {
+        return [
+            'username' => [
+                'required',
+                'string',
+                'max:50',
+                "unique:users,username,{$ignoreId},id",
+            ],
+            'first_name' => ['nullable', 'string', 'max:100'],
+            'last_name' => ['nullable', 'string', 'max:100'],
+            'nickname' => [
+                'required',
+                'string',
+                'max:50',
+                "unique:users,nickname,{$ignoreId},id",
+            ],
+            'email' => [
+                'nullable',
+                'email',
+                "unique:users,email,{$ignoreId},id",
+            ],
+            'password' => [$ignoreId ? 'sometimes' : 'required', 'string', 'min:8'],
+            'status' => ['required', 'in:active,inactive'],
+        ];
+    }
+
+    public const MESSAGES = [
+        'username.required' => 'Username wajib diisi.',
+        'username.unique' => 'Username sudah digunakan.',
+        'nickname.required' => 'Nama panggilan wajib diisi.',
+        'nickname.unique' => 'Nama panggilan sudah digunakan.',
+        'email.email' => 'Format email tidak valid.',
+        'email.unique' => 'Email sudah digunakan.',
+        'password.required' => 'Password wajib diisi.',
+        'password.min' => 'Password minimal 8 karakter.',
+    ];
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -26,11 +26,20 @@ class UserFactory extends Factory
      */
     public function definition(): array
     {
+        $firstName = $this->faker->firstName();
+        $lastName = $this->faker->lastName();
+        $shortLast = substr($lastName, 0, 1);
+        $nickname = "{$firstName} {$shortLast}";
+        $username = strtolower($this->generateUsername($firstName, $lastName));
+        $email = strtolower($username . "@gbipelita4.com");
+
         return [
             'id' => $this->faker->uuid(),
-            'name' => $this->faker->name(),
-            'username' => $this->faker->unique()->username(),
-            'email' => $this->faker->unique()->safeEmail(),
+            'username' => $username,
+            'nickname' => $nickname,
+            'first_name' => $firstName,
+            'last_name' => $lastName,
+            'email' => $email,
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('asdfasdf'), // default password
             'status' => 'active',
@@ -38,12 +47,27 @@ class UserFactory extends Factory
         ];
     }
 
+    private function generateUsername(string $firstName, string $lastName): string
+    {
+        // ambil 1–2 huruf dari last name, untuk variasi
+        $shortLast = substr($lastName, 0, 2);
+
+        // kadang tambahkan angka random biar unik
+        $username = strtolower($firstName . $shortLast);
+
+        if (rand(0, 1)) {
+            $username .= rand(10, 99);
+        }
+
+        return $username;
+    }
+
     /**
      * Indicate that the model's email address should be unverified.
      */
     public function unverified(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn(array $attributes) => [
             'email_verified_at' => null,
         ]);
     }

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -13,8 +13,10 @@ return new class extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->uuid('id')->primary();
-            $table->string('name');
             $table->string('username')->unique();
+            $table->string('first_name')->nullable();
+            $table->string('last_name')->nullable();
+            $table->string('nickname')->unique();
             $table->string('email')->unique()->nullable();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');

--- a/database/migrations/2025_10_02_210708_create_permissions_meta_table.php
+++ b/database/migrations/2025_10_02_210708_create_permissions_meta_table.php
@@ -14,7 +14,6 @@ return new class extends Migration
         Schema::create('permissions_metas', function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->string('module')->index();
-            // $table->string('parent_menu')->nullable();
             $table->string('menu')->nullable();
             $table->string('route_name')->unique();
             $table->string('permission_name')->unique();

--- a/database/migrations/2025_10_12_164341_create_modules_table.php
+++ b/database/migrations/2025_10_12_164341_create_modules_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('modules', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('name')->unique();
+            $table->string('slug')->unique();
+            $table->string('icon')->nullable();
+            $table->integer('order')->default(0);
+            $table->string('description')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::table('permissions_metas', function (Blueprint $table) {
+            $table->uuid('module_id')->index()->nullable()->after('id');
+            $table->foreign('module_id')->references('id')->on('modules')->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('permissions_metas', function (Blueprint $table) {
+            $table->dropForeign(['module_id']);
+            $table->dropColumn('module_id');
+        });
+
+        Schema::dropIfExists('modules');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,6 +13,8 @@ class DatabaseSeeder extends Seeder
     {
         $this->call([
             RolesAndPermissionsSeeder::class,
+            ModulesSeeder::class,
+            SyncPermissionSeeder::class,
             UserSeeder::class,
             DepartmentSeeder::class,
             DivisionSeeder::class,

--- a/database/seeders/ModulesSeeder.php
+++ b/database/seeders/ModulesSeeder.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Module;
+use App\Models\PermissionsMeta;
+use Illuminate\Support\Str;
+
+class ModulesSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $orders = [
+            'master' => 1,
+            'schedule' => 2,
+            'authorization' => 99,
+        ];
+
+        $modules = PermissionsMeta::select('module')
+            ->distinct()
+            ->pluck('module');
+
+        foreach ($modules as $moduleName) {
+            Module::updateOrCreate(
+                ['slug' => Str::slug($moduleName)],
+                [
+                    'name' => $moduleName,
+                    'description' => ucfirst(str_replace('_', ' ', $moduleName)),
+                    'order' => $orders[$moduleName] ?? 0,
+                ]
+            );
+        }
+
+        // Update module_id pada permissions_metas
+        foreach ($modules as $moduleName) {
+            $module = Module::where('slug', Str::slug($moduleName))->first();
+
+            PermissionsMeta::where('module', $moduleName)
+                ->update(['module_id' => $module->id]);
+        }
+    }
+}

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 use App\Models\PermissionsMeta;
 use Spatie\Permission\Models\Role;
 use Spatie\Permission\Models\Permission;
@@ -13,121 +14,136 @@ class RolesAndPermissionsSeeder extends Seeder
     {
         app()[\Spatie\Permission\PermissionRegistrar::class]->forgetCachedPermissions();
 
-        $permissions = [
-            'master' => [
-                'Pengguna' => [
-                    ['route' => 'users.view',               'action' => 'view',         'permission' => 'view-users'],
-                    ['route' => 'users.create',             'action' => 'create',       'permission' => 'create-users'],
-                    ['route' => 'users.edit',               'action' => 'edit',         'permission' => 'update-users'],
-                    ['route' => 'users.delete',             'action' => 'delete',       'permission' => 'delete-users'],
-                    ['route' => 'users.restore',            'action' => 'restore',      'permission' => 'restore-users'],
-                    ['route' => 'users.force-delete',       'action' => 'force-delete', 'permission' => 'force-delete-users'],
+        DB::transaction(function () {
+            $permissions = [
+                'master' => [
+                    'Pengguna' => [
+                        ['route' => 'users.view', 'action' => 'view', 'permission' => 'view-users'],
+                        ['route' => 'users.create', 'action' => 'create', 'permission' => 'create-users'],
+                        ['route' => 'users.edit', 'action' => 'edit', 'permission' => 'update-users'],
+                        ['route' => 'users.delete', 'action' => 'delete', 'permission' => 'delete-users'],
+                        ['route' => 'users.restore', 'action' => 'restore', 'permission' => 'restore-users'],
+                        ['route' => 'users.force-delete', 'action' => 'force-delete', 'permission' => 'force-delete-users'],
+                    ],
+                    'Departemen' => [
+                        ['route' => 'departments.view', 'action' => 'view', 'permission' => 'view-departments'],
+                        ['route' => 'departments.create', 'action' => 'create', 'permission' => 'create-departments'],
+                        ['route' => 'departments.edit', 'action' => 'edit', 'permission' => 'update-departments'],
+                        ['route' => 'departments.delete', 'action' => 'delete', 'permission' => 'delete-departments'],
+                        ['route' => 'departments.restore', 'action' => 'restore', 'permission' => 'restore-departments'],
+                        ['route' => 'departments.force-delete', 'action' => 'force-delete', 'permission' => 'force-delete-departments'],
+                    ],
                 ],
-
-                'Role' => [
-                    ['route' => 'roles.view',               'action' => 'view',         'permission' => 'view-roles'],
-                    ['route' => 'roles.create',             'action' => 'create',       'permission' => 'create-roles'],
-                    ['route' => 'roles.edit',               'action' => 'edit',         'permission' => 'update-roles'],
-                    ['route' => 'roles.delete',             'action' => 'delete',       'permission' => 'delete-roles'],
-                    ['route' => 'roles.restore',            'action' => 'restore',      'permission' => 'restore-roles'],
-                    ['route' => 'roles.force-delete',       'action' => 'force-delete', 'permission' => 'force-delete-roles'],
+                'schedule' => [
+                    'Lihat Jadwal' => [
+                        ['route' => 'schedules.view', 'action' => 'view', 'permission' => 'view-schedules'],
+                    ],
+                    'Isi Ketersediaan' => [
+                        ['route' => 'schedule.availability', 'action' => 'add', 'permission' => 'schedules-availability'],
+                    ],
+                    'Tugaskan Jadwal' => [
+                        ['route' => 'schedule.assign', 'action' => 'edit', 'permission' => 'schedules-assign-manual'],
+                    ],
                 ],
-
-                'Departemen' => [
-                    ['route' => 'departments.view',         'action' => 'view',         'permission' => 'view-departments'],
-                    ['route' => 'departments.create',       'action' => 'create',       'permission' => 'create-departments'],
-                    ['route' => 'departments.edit',         'action' => 'edit',         'permission' => 'update-departments'],
-                    ['route' => 'departments.delete',       'action' => 'delete',       'permission' => 'delete-departments'],
-                    ['route' => 'departments.restore',      'action' => 'restore',      'permission' => 'restore-departments'],
-                    ['route' => 'departments.force-delete', 'action' => 'force-delete', 'permission' => 'force-delete-departments'],
-                ],
-            ],
-            'schedule' => [
-                'Lihat Jadwal' => [
-                    ['route' => 'schedules.view',           'action' => 'view',         'permission' => 'view-schedules'],
-                ],
-                'Isi Ketersediaan' => [
-                    ['route' => 'schedule.availability',    'action' => 'add',          'permission' => 'schedules-availability'],
-                ],
-                'Tugaskan Jadwal' => [
-                    ['route' => 'schedule.assign',          'action' => 'edit',         'permission' => 'schedules-assign-manual'],
+                'authorization' => [
+                    'Menu' => [
+                        ['route' => 'menus.view', 'action' => 'view', 'permission' => 'view-menus'],
+                        ['route' => 'menus.create', 'action' => 'create', 'permission' => 'create-menus'],
+                        ['route' => 'menus.edit', 'action' => 'edit', 'permission' => 'update-menus'],
+                        ['route' => 'menus.delete', 'action' => 'delete', 'permission' => 'delete-menus'],
+                        ['route' => 'menus.restore', 'action' => 'restore', 'permission' => 'restore-menus'],
+                        ['route' => 'menus.force-delete', 'action' => 'force-delete', 'permission' => 'force-delete-menus'],
+                    ],
+                    'Role' => [
+                        ['route' => 'roles.view', 'action' => 'view', 'permission' => 'view-roles'],
+                        ['route' => 'roles.create', 'action' => 'create', 'permission' => 'create-roles'],
+                        ['route' => 'roles.edit', 'action' => 'edit', 'permission' => 'update-roles'],
+                        ['route' => 'roles.delete', 'action' => 'delete', 'permission' => 'delete-roles'],
+                        ['route' => 'roles.restore', 'action' => 'restore', 'permission' => 'restore-roles'],
+                        ['route' => 'roles.force-delete', 'action' => 'force-delete', 'permission' => 'force-delete-roles'],
+                    ],
+                    'Permission' => [
+                        ['route' => 'permissions.view', 'action' => 'view', 'permission' => 'view-permissions'],
+                    ],
                 ]
-            ]
-        ];
+            ];
 
-        // 1️. Buat permission & metadata
-        foreach ($permissions as $module => $menus) {
-            foreach ($menus as $menu => $items) {
-                foreach ($items as $perm) {
-                    Permission::firstOrCreate([
-                        'name' => $perm['permission'],
-                        'guard_name' => 'api',
-                    ]);
+            // 🔹 Buat permission + metadata
+            foreach ($permissions as $module => $menus) {
+                foreach ($menus as $menu => $items) {
+                    foreach ($items as $perm) {
+                        Permission::firstOrCreate([
+                            'name' => $perm['permission'],
+                            'guard_name' => 'api',
+                        ]);
 
-                    PermissionsMeta::updateOrCreate(
-                        ['permission_name' => $perm['permission']],
-                        [
-                            'module' => $module,
-                            'menu' => $menu,
-                            'route_name' => $perm['route'],
-                            'action' => $perm['action'],
-                        ]
-                    );
+                        PermissionsMeta::updateOrCreate(
+                            ['permission_name' => $perm['permission']],
+                            [
+                                'module' => $module,
+                                'menu' => $menu,
+                                'route_name' => $perm['route'],
+                                'action' => $perm['action'],
+                            ]
+                        );
+                    }
                 }
             }
-        }
 
-        // 2️. Buat role
-        $roles = [
-            'developer',
-            'pastor_youth',
-            'pastor_ic',
-            'department_head',
-            'division_leader',
-            'core_team',
-            'volunteer',
-            'congregation',
-            'guest',
-        ];
+            // 🔹 Buat roles
+            $roles = [
+                'developer',
+                'admin',
+                'pastor_youth',
+                'pastor_ic',
+                'department_head',
+                'division_leader',
+                'core_team',
+                'volunteer',
+                'congregation',
+                'guest',
+            ];
 
-        foreach ($roles as $roleName) {
-            Role::firstOrCreate([
-                'name' => $roleName,
-                'guard_name' => 'api',
+            foreach ($roles as $roleName) {
+                Role::firstOrCreate([
+                    'name' => $roleName,
+                    'guard_name' => 'api',
+                ]);
+            }
+
+            // 🔹 Assign permission ke role
+            Role::findByName('developer', 'api')->givePermissionTo(Permission::all());
+            Role::findByName('admin', 'api')->givePermissionTo(Permission::all());
+
+            Role::findByName('pastor_youth', 'api')->syncPermissions([
+                'view-users',
+                'view-schedules',
             ]);
-        }
 
-        // 3️. Assign permission ke role
-        Role::findByName('developer', 'api')->givePermissionTo(Permission::all());
+            Role::findByName('department_head', 'api')->syncPermissions([
+                'view-users',
+                'view-roles',
+                'create-roles',
+                'update-roles',
+                'view-schedules',
+                'schedules-assign-manual',
+            ]);
 
-        Role::findByName('pastor_youth', 'api')->givePermissionTo([
-            'view-users',
-            'view-schedules',
-        ]);
+            Role::findByName('division_leader', 'api')->syncPermissions([
+                'view-users',
+                'view-schedules',
+                'schedules-assign-manual',
+            ]);
 
-        Role::findByName('department_head', 'api')->givePermissionTo([
-            'view-users',
-            'view-roles',
-            'create-roles',
-            'update-roles',
-            'view-schedules',
-            'schedules-assign-manual',
-        ]);
+            Role::findByName('core_team', 'api')->syncPermissions([
+                'view-schedules',
+                'schedules-availability',
+            ]);
 
-        Role::findByName('division_leader', 'api')->givePermissionTo([
-            'view-users',
-            'view-schedules',
-            'schedules-assign-manual',
-        ]);
-
-        Role::findByName('core_team', 'api')->givePermissionTo([
-            'view-schedules',
-            'schedules-availability',
-        ]);
-
-        Role::findByName('volunteer', 'api')->givePermissionTo([
-            'view-schedules',
-            'schedules-availability',
-        ]);
+            Role::findByName('volunteer', 'api')->syncPermissions([
+                'view-schedules',
+                'schedules-availability',
+            ]);
+        });
     }
 }

--- a/database/seeders/SyncPermissionSeeder.php
+++ b/database/seeders/SyncPermissionSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\PermissionsMeta;
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Permission;
+
+class SyncPermissionSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $metas = PermissionsMeta::all();
+
+        foreach ($metas as $meta) {
+            Permission::updateOrCreate(
+                ['name' => $meta->permission_name],
+                ['guard_name' => 'web']
+            );
+        }
+    }
+}

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -16,9 +16,23 @@ class UserSeeder extends Seeder
         User::factory()
             ->withRole('developer')
             ->create([
-                'name' => 'Developer',
                 'username' => 'developer',
+                'nickname' => 'Developer',
+                'first_name' => 'Dewa',
+                'last_name' => 'Developer',
                 'email' => 'developer@developer.com',
+                'password' => bcrypt('asdfasdf'),
+                'status' => 'active'
+            ]);
+
+        User::factory()
+            ->withRole('admin')
+            ->create([
+                'username' => 'admin',
+                'nickname' => 'Admin',
+                'first_name' => 'Super',
+                'last_name' => 'Admin',
+                'email' => 'admin@gbipelita4.com',
                 'password' => bcrypt('asdfasdf'),
                 'status' => 'active'
             ]);
@@ -27,19 +41,23 @@ class UserSeeder extends Seeder
         // Jaya (Pastor Youth + Department Head)
         User::factory()
             ->create([
-                'name' => 'Jaya',
                 'username' => 'jaya',
+                'nickname' => 'Jaya',
+                'first_name' => 'Jayanta',
+                'last_name' => 'Bangun',
                 'email' => 'jaya@gbipelita4.com',
                 'password' => bcrypt('asdfasdf'),
                 'status' => 'active'
             ])
             ->assignRole(['pastor_youth', 'department_head']);
-            
+
         // Mahenja (Division Leader + Core Team)
         User::factory()
             ->create([
-                'name' => 'Mahenja',
                 'username' => 'mahenja',
+                'nickname' => 'Mahenja',
+                'first_name' => 'Dimas',
+                'last_name' => 'S Panjaitan',
                 'email' => 'mahenja@gbipelita4.com',
                 'password' => bcrypt('asdfasdf'),
                 'status' => 'active'
@@ -49,8 +67,10 @@ class UserSeeder extends Seeder
         // Mahenja (Division Leader + Core Team)
         User::factory()
             ->create([
-                'name' => 'Laora',
                 'username' => 'laora',
+                'nickname' => 'Laora',
+                'first_name' => 'Laora',
+                'last_name' => 'Simanjuntak',
                 'email' => 'laora@gbipelita4.com',
                 'password' => bcrypt('asdfasdf'),
                 'status' => 'active'

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,8 @@
 <?php
 
 require __DIR__ . '/auth.php';
+require __DIR__ . '/module.php';
+require __DIR__ . '/permission.php';
 require __DIR__ . '/user.php';
 require __DIR__ . '/master.php';
 require __DIR__ . '/department.php';

--- a/routes/module.php
+++ b/routes/module.php
@@ -1,0 +1,10 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Module\IndexController;
+
+Route::middleware(['auth:sanctum', 'role:developer'])
+    ->prefix('modules')
+    ->group(function () {
+        Route::get('/', IndexController::class);
+    });

--- a/routes/permission.php
+++ b/routes/permission.php
@@ -1,0 +1,10 @@
+<?php
+
+use App\Http\Controllers\Permission\IndexController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware(['auth:sanctum', 'role:developer'])
+    ->prefix('permissions')
+    ->group(function () {
+        Route::get('/', IndexController::class);
+    });

--- a/structure.md
+++ b/structure.md
@@ -1,7 +1,9 @@
 - User:
         - id: uuid|primary
-        - name: string|required
         - username: string|required
+        - first_name: string|nullable
+        - last_name: string|nullable
+        - nickname: string|required
         - email: string|nullable
         - password: string|required
         - status: string|default:active|index|required  // ['active', 'inactive']
@@ -83,10 +85,18 @@
 
 - PermissionMeta
         - id: uuid|primary
+        - module_id: uuid|index|nullable
         - module: string|index
-        - parent_menu: string|nullable
         - menu: string|nullable
         - route_name: string|unique
         - permission_name: string|unique
         - action: string
         - description: text|nullable
+
+- Module
+        - id: uuid|primary
+        - name: string|unique
+        - slug: string|unique
+        - icon: string|nullable
+        - order: integer|default:0
+        - description: string|nullable


### PR DESCRIPTION
- `Module` model, migration, and seeder (`ModulesSeeder`) for modular permission grouping.
- `app/Http/Controllers/Module/IndexController.php` — list modules with related permissions.
- `app/Http/Controllers/Permission/IndexController.php` — list permissions grouped by module/menu.
- `routes/module.php` and `routes/permission.php` — separated route modules for cleaner structure.
- `SyncPermissionSeeder` — synchronize `permissions_metas` with Spatie permissions.

- Updated `RolesAndPermissionsSeeder` to register permissions dynamically with new module-based structure.
- Modified `PermissionsMeta` model to include `module_id` relation.
- Adjusted `User` and `Department` models & requests for validation consistency.
- Updated `DatabaseSeeder` to include `ModulesSeeder` and `SyncPermissionSeeder` in seeding order.
- Modified `api.php` to load new route groups.
- Refined structure documentation (`structure.md`) accordingly.

- Added `2025_10_12_164341_create_modules_table.php` with FK link to `permissions_metas`.
- Updated `2025_10_02_210708_create_permissions_meta_table.php` to align with module relation.
- Adjusted `create_users_table` migration for UUID and role consistency.

- Ensure migration order: `RolesAndPermissionsSeeder` → `SyncPermissionSeeder` → `ModulesSeeder` → `UserSeeder`.
- Run `php artisan migrate:fresh --seed` after merging this change to apply new FK constraints cleanly.